### PR TITLE
Introducing a non-blocking images cache to prevent Idea's freeze on startup

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id 'org.jetbrains.intellij' version '0.3.5'
-    id 'org.jetbrains.kotlin.jvm' version '1.2.51'
+    id 'org.jetbrains.kotlin.jvm' version '1.3.11'
 }
 
 group 'no.name'
@@ -12,7 +12,6 @@ repositories {
 }
 
 dependencies {
-    compile 'org.jetbrains.kotlinx:kotlinx-coroutines-core:0.22.5'
     compile "org.jetbrains.kotlin:kotlin-stdlib-jdk8"
     compile 'com.palominolabs.http:url-builder:1.1.1'
     compile "com.fasterxml.jackson.core:jackson-databind:2.6.5"
@@ -29,15 +28,10 @@ intellij {
     version '2018.2'
     plugins 'git4idea'
     pluginName 'BitbucketHelper4Idea'
-    alternativeIdePath 'C:\\Program Files\\JetBrains\\IntelliJ IDEA Community Edition 2018.2'
+    alternativeIdePath 'C:\\Program Files\\JetBrains\\IntelliJ IDEA Community Edition 2018.2.6'
 }
 patchPluginXml {
     changeNotes """
       Add change notes here.<br>
       <em>most HTML tags may be used</em>"""
-}
-kotlin {
-    experimental {
-        coroutines "enable"
-    }
 }

--- a/src/main/kotlin/UpdateTaskHolder.kt
+++ b/src/main/kotlin/UpdateTaskHolder.kt
@@ -1,5 +1,6 @@
 import bitbucket.BitbucketClient
 import bitbucket.BitbucketClientFactory
+import com.intellij.openapi.diagnostic.Logger
 import com.intellij.util.concurrency.AppExecutorUtil
 import kotlinx.coroutines.experimental.Deferred
 import kotlinx.coroutines.experimental.Runnable
@@ -10,6 +11,7 @@ import java.util.concurrent.TimeUnit
 import java.util.function.Consumer
 
 object UpdateTaskHolder {
+    private val log = Logger.getInstance(UpdateTaskHolder::class.java)
     var future: ScheduledFuture<*>? = null // todo get rid of null, find more right way to store
 
     fun reschedule() {
@@ -21,19 +23,9 @@ object UpdateTaskHolder {
 
     class UpdateTask(private val client: BitbucketClient) : Runnable {
         override fun run() {
-            process(client.reviewedPRs(), Consumer {
-                Model.updateReviewingPRs(it)
-            })
-            process(client.ownPRs(), Consumer {
-                Model.updateOwnPRs(it)
-            })
-        }
-    }
-
-    private fun <T> process(obs: Deferred<List<T>>, consumer: Consumer<List<T>>) {
-        runBlocking {
-            val prs = obs.await()
-            consumer.accept(prs)
+            log.debug("Running UpdateTask...")
+            Model.updateReviewingPRs(client.reviewedPRs())
+            Model.updateOwnPRs(client.ownPRs())
         }
     }
 }

--- a/src/main/kotlin/http/HttpResponseHandler.kt
+++ b/src/main/kotlin/http/HttpResponseHandler.kt
@@ -2,6 +2,7 @@ package http
 
 import com.fasterxml.jackson.core.type.TypeReference
 import com.fasterxml.jackson.databind.ObjectReader
+import com.intellij.openapi.diagnostic.Logger
 import org.apache.http.HttpResponse
 import org.apache.http.HttpStatus
 import java.io.InputStream
@@ -11,6 +12,7 @@ class HttpResponseHandler<T>(private val objectReader: ObjectReader, private val
     fun handle(response: HttpResponse): T = process(response) { objectReader.forType(bodyType).readValue(it) }
 
     companion object {
+        private val log = Logger.getInstance("HttpResponseHandler")
         /**
          * Use this handle when response body is empty or is not needed
          */
@@ -21,6 +23,7 @@ class HttpResponseHandler<T>(private val objectReader: ObjectReader, private val
         private fun  <T> process(response: HttpResponse, mapper: (InputStream) -> T ): T {
             val status = response.statusLine
             val statusCode =  status.statusCode
+            log.debug("Status code received: $statusCode")
             return when (statusCode) {
                 HttpStatus.SC_OK -> mapper.invoke(response.entity.content)
                 HttpStatus.SC_UNAUTHORIZED -> throw UnauthorizedException

--- a/src/main/kotlin/ui/ImagesSource.kt
+++ b/src/main/kotlin/ui/ImagesSource.kt
@@ -1,0 +1,45 @@
+package ui
+
+import com.intellij.openapi.diagnostic.Logger
+import com.intellij.util.concurrency.AppExecutorUtil
+import java.awt.image.BufferedImage
+import java.io.IOException
+import java.net.URL
+import java.util.concurrent.*
+import javax.imageio.ImageIO
+
+class ImagesSource: MediaSource<BufferedImage> {
+    //The key is String, not java.net.URL, because URL's hashCode() and equals() are blocking operations
+    private val cachedImages: MutableMap<String /* url */, CompletableFuture<BufferedImage>> = ConcurrentHashMap()
+    private val executor: ExecutorService = AppExecutorUtil.getAppExecutorService()
+    private val defaultAvatar = resourceImage("avatar.png")
+
+    override fun retrieve(url: URL): CompletableFuture<BufferedImage> {
+        return cachedImages.computeIfAbsent(url.toString()) {
+            val future = CompletableFuture<BufferedImage>()
+            executor.submit(GetImageTask(url, defaultAvatar, future))
+            future
+        }
+    }
+
+    private fun resourceImage(relativePath: String) =
+            javaClass.classLoader.getResource(relativePath)
+
+    class GetImageTask(
+            private val url: URL,
+            private val defaultUrl: URL,
+            private val future: CompletableFuture<BufferedImage>
+    ): Runnable {
+        private val log = Logger.getInstance("GetImageTask")
+
+        override fun run() {
+            log.debug("Running GetImageTask for url: $url")
+            try {
+                future.complete(ImageIO.read(url))
+            } catch (e: IOException) {
+                log.warn("Cannot read image by URL: $url")
+            }
+            future.complete(ImageIO.read(defaultUrl))
+        }
+    }
+}

--- a/src/main/kotlin/ui/MediaSource.kt
+++ b/src/main/kotlin/ui/MediaSource.kt
@@ -1,45 +1,8 @@
 package ui
 
-import com.intellij.openapi.diagnostic.Logger
-import com.intellij.util.concurrency.AppExecutorUtil
-import java.awt.image.BufferedImage
-import java.io.IOException
 import java.net.URL
-import java.util.concurrent.*
-import javax.imageio.ImageIO
+import java.util.concurrent.CompletableFuture
 
-class MediaSource {
-    //The key is String, not java.net.URL, because URL's hashCode() and equals() are blocking operations
-    private val cachedImages: MutableMap<String /* url */, CompletableFuture<BufferedImage>> = ConcurrentHashMap()
-    private val executor: ExecutorService = AppExecutorUtil.getAppExecutorService()
-    private val defaultAvatar = resourceImage("avatar.png")
-
-    fun retrieveImage(url: URL): CompletableFuture<BufferedImage> {
-        return cachedImages.computeIfAbsent(url.toString()) {
-            val future = CompletableFuture<BufferedImage>()
-            executor.submit(GetImageTask(url, defaultAvatar, future))
-            future
-        }
-    }
-
-    private fun resourceImage(relativePath: String) =
-            javaClass.classLoader.getResource(relativePath)
-
-    class GetImageTask(
-            private val url: URL,
-            private val defaultUrl: URL,
-            private val future: CompletableFuture<BufferedImage>
-    ): Runnable {
-        private val log = Logger.getInstance("GetImageTask")
-
-        override fun run() {
-            log.debug("Running GetImageTask for url: $url")
-            try {
-                future.complete(ImageIO.read(url))
-            } catch (e: IOException) {
-                log.warn("Cannot read image by URL: $url")
-            }
-            future.complete(ImageIO.read(defaultUrl))
-        }
-    }
+interface MediaSource<T> {
+    fun retrieve(url: URL): CompletableFuture<T>
 }

--- a/src/main/kotlin/ui/MediaSource.kt
+++ b/src/main/kotlin/ui/MediaSource.kt
@@ -1,0 +1,44 @@
+package ui
+
+import com.intellij.openapi.diagnostic.Logger
+import com.intellij.util.concurrency.AppExecutorUtil
+import java.awt.image.BufferedImage
+import java.io.IOException
+import java.net.URL
+import java.util.concurrent.*
+import javax.imageio.ImageIO
+
+class MediaSource {
+    //The key is String, not java.net.URL, because URL's hashCode() and equals() are blocking operations
+    private val cachedImages: MutableMap<String /* url */, CompletableFuture<BufferedImage>> = ConcurrentHashMap()
+    private val executor: ExecutorService = AppExecutorUtil.getAppExecutorService()
+    private val defaultAvatar = resourceImage("avatar.png")
+
+    fun retrieveImage(url: URL): CompletableFuture<BufferedImage> {
+        return cachedImages.computeIfAbsent(url.toString()) {
+            val future = CompletableFuture<BufferedImage>()
+            executor.submit(GetImageTask(url, defaultAvatar, future))
+            future
+        }
+    }
+
+    private fun resourceImage(relativePath: String) =
+            javaClass.classLoader.getResource(relativePath)
+
+    class GetImageTask(
+            private val url: URL,
+            private val defaultUrl: URL,
+            private val future: CompletableFuture<BufferedImage>
+    ): Runnable {
+        private val log = Logger.getInstance("GetImageTask")
+
+        override fun run() {
+            try {
+                future.complete(ImageIO.read(url))
+            } catch (e: IOException) {
+                log.warn("Cannot read image by URL: $url")
+            }
+            future.complete(ImageIO.read(defaultUrl))
+        }
+    }
+}

--- a/src/main/kotlin/ui/MediaSource.kt
+++ b/src/main/kotlin/ui/MediaSource.kt
@@ -33,6 +33,7 @@ class MediaSource {
         private val log = Logger.getInstance("GetImageTask")
 
         override fun run() {
+            log.debug("Running GetImageTask for url: $url")
             try {
                 future.complete(ImageIO.read(url))
             } catch (e: IOException) {

--- a/src/main/kotlin/ui/PRComponent.kt
+++ b/src/main/kotlin/ui/PRComponent.kt
@@ -59,7 +59,7 @@ class PRComponent(val pr: PR, private val imagesSource: MediaSource): JPanel() {
         c.weightx = 1.0
         c.fill = GridBagConstraints.EAST
         c.gridx = 2
-        val buttonSize = Dimension(120, 36)
+        val buttonSize = Dimension(120, 24)
         approveBtn.preferredSize = buttonSize
         approveBtn.addActionListener {
             Model.approve(pr, Consumer {approved ->
@@ -113,7 +113,7 @@ class PRComponent(val pr: PR, private val imagesSource: MediaSource): JPanel() {
             add(picLabel, c)
             //todo there is will be a problem then a number of reviewers is high. Better approach is
             //todo to show 2 first reviewers and to hide others in pop up menu
-            reviewerOffset += 50
+            reviewerOffset += 30
         }
     }
 }

--- a/src/main/kotlin/ui/Panel.kt
+++ b/src/main/kotlin/ui/Panel.kt
@@ -4,9 +4,14 @@ import java.awt.GridBagLayout
 import javax.swing.JPanel
 import java.awt.GridBagConstraints
 import java.awt.Insets
+import java.awt.image.BufferedImage
+import java.util.concurrent.Executor
 
 
-abstract class Panel(private val imagesSource: MediaSource) : JPanel(), Listener {
+abstract class Panel(
+    private val imagesSource: MediaSource<BufferedImage>,
+    private val awtExecutor: Executor) : JPanel(), Listener {
+
     private val gbc: GridBagConstraints = GridBagConstraints()
 
     init {
@@ -21,7 +26,7 @@ abstract class Panel(private val imagesSource: MediaSource) : JPanel(), Listener
 
     fun dataUpdated(diff: Diff) {
         diff.added.values.sortedBy { it.updatedAt }
-                .forEach{ add(PRComponent(it, imagesSource), gbc, 0) }
+                .forEach{ add(PRComponent(it, imagesSource, awtExecutor), gbc, 0) }
 
         synchronized(treeLock) {
             for (i in 0 until componentCount) {

--- a/src/main/kotlin/ui/Panel.kt
+++ b/src/main/kotlin/ui/Panel.kt
@@ -6,8 +6,8 @@ import java.awt.GridBagConstraints
 import java.awt.Insets
 
 
-abstract class Panel : JPanel(), Listener {
-    val gbc:GridBagConstraints = GridBagConstraints()
+abstract class Panel(private val imagesSource: MediaSource) : JPanel(), Listener {
+    private val gbc: GridBagConstraints = GridBagConstraints()
 
     init {
         val layout = GridBagLayout()
@@ -21,7 +21,7 @@ abstract class Panel : JPanel(), Listener {
 
     fun dataUpdated(diff: Diff) {
         diff.added.values.sortedBy { it.updatedAt }
-                .forEach{ add(PRComponent(it), gbc, 0) }
+                .forEach{ add(PRComponent(it, imagesSource), gbc, 0) }
 
         synchronized(treeLock) {
             for (i in 0 until componentCount) {

--- a/src/main/kotlin/ui/PanelFactory.kt
+++ b/src/main/kotlin/ui/PanelFactory.kt
@@ -1,13 +1,17 @@
 package ui
 
+import com.intellij.openapi.application.ApplicationManager
 import com.intellij.ui.components.JBScrollPane
+import java.awt.image.BufferedImage
+import java.util.concurrent.Executor
 import javax.swing.JPanel
 import javax.swing.JScrollPane
 
-val imagesSource = MediaSource()
+var imagesSource: MediaSource<BufferedImage> = ImagesSource()
+var awtExecutor: Executor = Executor { command -> ApplicationManager.getApplication().invokeLater(command) }
 
 fun createReviewPanel(): Panel {
-    return object : Panel(imagesSource) {
+    return object : Panel(imagesSource, awtExecutor) {
         override fun ownUpdated(diff: Diff) {}
 
         override fun reviewedUpdated(diff: Diff) {
@@ -17,7 +21,7 @@ fun createReviewPanel(): Panel {
 }
 
 fun createOwnPanel(): Panel {
-    return object : Panel(imagesSource) {
+    return object : Panel(imagesSource, awtExecutor) {
         override fun ownUpdated(diff: Diff) {
             dataUpdated(diff)
         }

--- a/src/main/kotlin/ui/PanelFactory.kt
+++ b/src/main/kotlin/ui/PanelFactory.kt
@@ -4,8 +4,10 @@ import com.intellij.ui.components.JBScrollPane
 import javax.swing.JPanel
 import javax.swing.JScrollPane
 
+val imagesSource = MediaSource()
+
 fun createReviewPanel(): Panel {
-    return object : Panel() {
+    return object : Panel(imagesSource) {
         override fun ownUpdated(diff: Diff) {}
 
         override fun reviewedUpdated(diff: Diff) {
@@ -15,7 +17,7 @@ fun createReviewPanel(): Panel {
 }
 
 fun createOwnPanel(): Panel {
-    return object : Panel() {
+    return object : Panel(imagesSource) {
         override fun ownUpdated(diff: Diff) {
             dataUpdated(diff)
         }

--- a/src/main/kotlin/ui/ReviewerComponentFactory.kt
+++ b/src/main/kotlin/ui/ReviewerComponentFactory.kt
@@ -1,10 +1,10 @@
 package ui
 
 import bitbucket.data.PRParticipant
+import com.intellij.util.ui.UIUtil
 import java.awt.Image
 import java.awt.image.BufferedImage
 import java.io.IOException
-import java.net.URL
 import javax.imageio.ImageIO
 import javax.swing.ImageIcon
 import javax.swing.JLabel
@@ -15,8 +15,8 @@ object ReviewerComponentFactory {
     private val defaultAvatar = resourceImage("avatar.png")
 
     //it seems that bitbucket api v1 is not supply information about "need work" flags
-    fun create(reviewer: PRParticipant): JLabel {
-        val avatar = try { scaleImage(URL(reviewer.user.links.getIconHref())) } catch (e: IOException) { defaultAvatar }
+    fun create(reviewer: PRParticipant, reviewerAvatar: BufferedImage): JLabel {
+        val avatar = try { scaleImage(reviewerAvatar) } catch (e: IOException) { defaultAvatar }
         val icon = if (reviewer.approved) overlay(avatar, approved) else ImageIcon(avatar)
         val iconComponent =  JLabel(icon)
         iconComponent.toolTipText = reviewer.user.displayName
@@ -24,15 +24,15 @@ object ReviewerComponentFactory {
     }
 
     private fun overlay(image: Image, overlay: Image): ImageIcon {
-        val combined = BufferedImage(imageSize, imageSize, BufferedImage.TYPE_INT_ARGB)
+        val combined = UIUtil.createImage(imageSize, imageSize, BufferedImage.TYPE_INT_ARGB)
         val g = combined.graphics
         g.drawImage(image, 0, 0, null)
         g.drawImage(overlay, 0, 0, null)
         return ImageIcon(combined)
     }
 
-    private fun scaleImage(url: URL) = ImageIO.read(url).getScaledInstance(imageSize, imageSize, BufferedImage.SCALE_DEFAULT)
+    private fun scaleImage(image: BufferedImage) = image.getScaledInstance(imageSize, imageSize, BufferedImage.SCALE_DEFAULT)
 
-    private fun resourceImage(relativePath: String) = scaleImage(javaClass.classLoader.getResource(relativePath))
+    private fun resourceImage(relativePath: String) = scaleImage(ImageIO.read(javaClass.classLoader.getResource(relativePath)))
 
 }

--- a/src/main/kotlin/ui/ReviewerComponentFactory.kt
+++ b/src/main/kotlin/ui/ReviewerComponentFactory.kt
@@ -10,7 +10,7 @@ import javax.swing.ImageIcon
 import javax.swing.JLabel
 
 object ReviewerComponentFactory {
-    private const val imageSize = 40
+    private const val imageSize = 24
     private val approved = resourceImage("approved.png")
     private val defaultAvatar = resourceImage("avatar.png")
 

--- a/src/main/kotlin/ui/ReviewerComponentFactory.kt
+++ b/src/main/kotlin/ui/ReviewerComponentFactory.kt
@@ -2,10 +2,12 @@ package ui
 
 import bitbucket.data.PRParticipant
 import com.intellij.util.ui.UIUtil
+import java.awt.Color
 import java.awt.Image
 import java.awt.image.BufferedImage
 import java.io.IOException
 import javax.imageio.ImageIO
+import javax.swing.BorderFactory
 import javax.swing.ImageIcon
 import javax.swing.JLabel
 
@@ -20,6 +22,9 @@ object ReviewerComponentFactory {
         val icon = if (reviewer.approved) overlay(avatar, approved) else ImageIcon(avatar)
         val iconComponent =  JLabel(icon)
         iconComponent.toolTipText = reviewer.user.displayName
+        if (reviewer.approved) {
+            iconComponent.border = BorderFactory.createLineBorder(Color.green)
+        }
         return iconComponent
     }
 

--- a/src/test/kotlin/PanelRunner.kt
+++ b/src/test/kotlin/PanelRunner.kt
@@ -1,18 +1,31 @@
 import bitbucket.data.*
-import ui.Diff
-import ui.createReviewPanel
-import ui.wrapIntoScroll
+import ui.*
+import java.awt.image.BufferedImage
+import java.net.URL
 import java.util.*
+import java.util.concurrent.CompletableFuture
+import java.util.concurrent.Executor
+import javax.imageio.ImageIO
 import javax.swing.JFrame
+import javax.swing.SwingUtilities
 import kotlin.collections.HashMap
 
 object PanelRunner {
 
     val br = "feature/TOSX-1980-it-is-a-feature-that-has-a-workitem-branch"
+    val image = javaClass.classLoader.getResource("avatar.png")
 
     @JvmStatic
     fun main(args: Array<String>) {
         val frame = JFrame()
+        awtExecutor = Executor { command -> SwingUtilities.invokeLater(command) }
+        imagesSource = object: MediaSource<BufferedImage> {
+            override fun retrieve(url: URL): CompletableFuture<BufferedImage> {
+                val future = CompletableFuture<BufferedImage>()
+                future.complete(ImageIO.read(image))
+                return future
+            }
+        }
         val panel = createReviewPanel()
         val map = HashMap<Long, PR>()
         for (i in 1..20) {

--- a/src/test/kotlin/Runner.kt
+++ b/src/test/kotlin/Runner.kt
@@ -2,7 +2,6 @@ import bitbucket.BitbucketClient
 import com.fasterxml.jackson.databind.DeserializationFeature
 import com.fasterxml.jackson.databind.ObjectMapper
 import http.HttpAuthRequestFactory
-import kotlinx.coroutines.experimental.runBlocking
 import org.apache.http.impl.client.HttpClients
 import java.net.URL
 
@@ -17,9 +16,7 @@ object Runner {
                 URL(args[2]), args[3], args[3], args[0],
                 objectMapper.reader(), objectMapper.writer())
 
-        runBlocking {
-            client.ownPRs().await().forEach { println("OwnPR: $it") }
-            client.reviewedPRs().await().forEach { println("OwnPR: $it") }
-        }
+        client.ownPRs().forEach { println("OwnPR: $it") }
+        client.reviewedPRs().forEach { println("OwnPR: $it") }
     }
 }


### PR DESCRIPTION
The initial problem was downloading user images in the AWT event thread, which made Idea frozen for ~2 minutes.

What's done here:
1. Non-blocking caching Images Source is introduced, so we download each image only once.
2. The approach with coroutines is removed. We had to wait in AppExecutor for completion of the coroutines anyway (see UpdateTask#process), so it is more clear to do all the background work in the AppExecutor thread, which is a standard way that Idea's developers suggest.