### PR TITLE
Remove PRs properly, PRs vertical alignment

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -4,7 +4,7 @@ plugins {
 }
 
 group 'BigBurritoInc'
-version '0.1'
+version '0.1.1'
 
 repositories {
     mavenCentral()
@@ -33,5 +33,6 @@ intellij {
 }
 patchPluginXml {
     changeNotes """
+      v.0.1.1 2019.01.25 Minor bug fixes
       v.0.1: 2019.01.21 First public version is released"""
 }

--- a/src/main/kotlin/MainWindow.kt
+++ b/src/main/kotlin/MainWindow.kt
@@ -12,7 +12,6 @@ import ui.*
 import java.awt.*
 import java.awt.event.KeyEvent
 import java.awt.event.KeyListener
-import java.net.ConnectException
 import javax.swing.*
 
 
@@ -37,6 +36,7 @@ class MainWindow : ToolWindowFactory, DumbAware {
 
     private fun createLoginPanel(contentManager: ContentManager, reviewingContent: Content): JPanel {
         val wrapper = JPanel(BorderLayout())
+        val passwordLabel = JBLabel("Password:")
         val passwordField = JPasswordField()
         val messageField = JBLabel()
         val button = JButton("Login")
@@ -70,6 +70,7 @@ class MainWindow : ToolWindowFactory, DumbAware {
         })
         val panel = JPanel(VerticalLayout(5))
         panel.border = BorderFactory.createEmptyBorder(5, 5, 5, 5)
+        panel.add(passwordLabel)
         panel.add(passwordField)
         panel.add(button)
         panel.add(messageField)

--- a/src/main/kotlin/ui/PRComponent.kt
+++ b/src/main/kotlin/ui/PRComponent.kt
@@ -83,6 +83,7 @@ open class PRComponent(
         }
 
         border = UIUtil.getTextFieldBorder()
+        maximumSize = Dimension(Integer.MAX_VALUE, 160)
     }
 
     open fun addApproveButton(buttonSize: Dimension) {

--- a/src/main/kotlin/ui/Panel.kt
+++ b/src/main/kotlin/ui/Panel.kt
@@ -1,6 +1,7 @@
 package ui
 
 import bitbucket.data.PR
+import java.awt.Component
 import java.awt.GridBagLayout
 import javax.swing.JPanel
 import java.awt.GridBagConstraints
@@ -25,13 +26,13 @@ abstract class Panel : JPanel(), Listener {
         diff.added.values.sortedBy { it.updatedAt }
                 .forEach{ add(createPRComponent(it), gbc, 0) }
 
-        synchronized(treeLock) {
-            for (i in 0 until componentCount) {
-                val component = getComponent(i) as PRComponent
-                if (diff.removed.containsKey(component.pr.id))
-                    remove(i)
-            }
+        val toRemove = mutableListOf<Component>()
+        for (i in 0 until componentCount) {
+            val component = getComponent(i) as PRComponent
+            if (diff.removed.containsKey(component.pr.id))
+                toRemove.add(component)
         }
+        toRemove.forEach { remove(it) }
         repaint()
     }
 

--- a/src/main/kotlin/ui/Panel.kt
+++ b/src/main/kotlin/ui/Panel.kt
@@ -2,29 +2,21 @@ package ui
 
 import bitbucket.data.PR
 import java.awt.Component
-import java.awt.GridBagLayout
 import javax.swing.JPanel
-import java.awt.GridBagConstraints
-import java.awt.Insets
+import javax.swing.BoxLayout
+
+
 
 
 abstract class Panel : JPanel(), Listener {
 
-    private val gbc: GridBagConstraints = GridBagConstraints()
-
     init {
-        val layout = GridBagLayout()
-        gbc.fill = GridBagConstraints.HORIZONTAL
-        gbc.weightx = 1.0
-        gbc.gridx = 0
-        gbc.anchor = GridBagConstraints.WEST
-        gbc.insets = Insets(3, 3, 3, 3)
-        setLayout(layout)
+        layout = BoxLayout(this, BoxLayout.Y_AXIS)
     }
 
     fun dataUpdated(diff: Diff) {
         diff.added.values.sortedBy { it.updatedAt }
-                .forEach{ add(createPRComponent(it), gbc, 0) }
+                .forEach{ add(createPRComponent(it), 0) }
 
         val toRemove = mutableListOf<Component>()
         for (i in 0 until componentCount) {


### PR DESCRIPTION
#41 #42 are fixed here

The issue was we were iterating over PRComponents and removing them inside the cycle by id.
In result overall number of PRComponents could changes while iteration is happening and some of them were not removed.

