### PR TITLE
Update PR internal state after merge

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -4,7 +4,7 @@ plugins {
 }
 
 group 'BigBurritoInc'
-version '0.2-PREVIEW'
+version '0.2'
 
 repositories {
     mavenCentral()
@@ -33,11 +33,7 @@ intellij {
 }
 patchPluginXml {
     changeNotes """
-      v.0.2 2019.02.XX New interface, merge button for own pull request added, update after checkout;
-      
-      v.0.1.2 2019.01.29 Support for real-time updates of pull requests;
-      
-      v.0.1.1 2019.01.25 Minor bug fixes;
-      
-      v.0.1: 2019.01.21 First public version is released;"""
+      v.0.2 New visual interface, pull requests' merging, automatic git pull after branch checkout \n 
+      v.0.1.1 2019.01.25 Minor bug fixes \n
+      v.0.1: 2019.01.21 First public version is released"""
 }

--- a/build.gradle
+++ b/build.gradle
@@ -4,7 +4,7 @@ plugins {
 }
 
 group 'BigBurritoInc'
-version '0.1.1'
+version '0.2-PREVIEW'
 
 repositories {
     mavenCentral()
@@ -33,6 +33,11 @@ intellij {
 }
 patchPluginXml {
     changeNotes """
-      v.0.1.1 2019.01.25 Minor bug fixes
-      v.0.1: 2019.01.21 First public version is released"""
+      v.0.2 2019.02.XX New interface, merge button for own pull request added, update after checkout;
+      
+      v.0.1.2 2019.01.29 Support for real-time updates of pull requests;
+      
+      v.0.1.1 2019.01.25 Minor bug fixes;
+      
+      v.0.1: 2019.01.21 First public version is released;"""
 }

--- a/src/main/kotlin/ui/Model.kt
+++ b/src/main/kotlin/ui/Model.kt
@@ -108,6 +108,7 @@ object Model {
             try {
                 val newPRState = BitbucketClientFactory.createClient().merge(pr)
                 if (newPRState.closed) {
+                    own = own.update(listOf(newPRState))
                     showNotification("PR ${pr.title} is merged")
                     invokeLater { callback.accept(true) }
                 }

--- a/src/main/kotlin/ui/PRState.kt
+++ b/src/main/kotlin/ui/PRState.kt
@@ -7,7 +7,9 @@ class PRState(private val prsMap: Map<Long, PR> = HashMap()) {
         val newMap = prs.map { it.id to it }.toMap()
         val removed = prsMap.filterKeys { !newMap.containsKey(it) }
         val added = newMap.filterKeys { !prsMap.containsKey(it) }
-        val updated = newMap.filterKeys { prsMap.containsKey(it) && prsMap[it] != newMap[it] }
+        val updated = newMap.filterKeys { prsMap.containsKey(it) && prsMap[it] != newMap[it]
+        //It is not clear if any change leads to version change so if versions are equal consider it as a change
+                && prsMap.getValue(it).version <= newMap.getValue(it).version }
         val mergeStatusChanged = newMap.filter { !it.value.mergeStatus.unknown }
                 .filterKeys { prsMap.containsKey(it)
                     && prsMap[it]?.mergeStatus?.canMerge != newMap[it]?.mergeStatus?.canMerge }
@@ -17,6 +19,18 @@ class PRState(private val prsMap: Map<Long, PR> = HashMap()) {
     fun createNew(prs: List<PR>): PRState {
         return PRState(prs.map { it.id to it }.toMap())
     }
+
+    fun update(prs: List<PR>): PRState {
+        val newPRsMap = prs.map { it.id to it }.toMap()
+        return PRState(
+            prsMap.map { if (hasNewerVersion(newPRsMap, it)) { newPRsMap[it.key] } else { it.value } }
+                .filterNotNull() // we know no nulls there, but have to explain to Kotlin compiler explicitly
+                .map { it.id to it }.toMap()
+        )
+    }
+
+    private fun hasNewerVersion(newPRsMap: Map<Long, PR>, entry: Map.Entry<Long, PR>) =
+            (newPRsMap.containsKey(entry.key) && (entry.value.version < newPRsMap.getValue(entry.key).version))
 
     fun size() = prsMap.size
 }

--- a/src/test/kotlin/PRStateTest.kt
+++ b/src/test/kotlin/PRStateTest.kt
@@ -1,0 +1,44 @@
+import bitbucket.data.*
+import org.junit.Ignore
+import org.junit.Test
+import ui.PRState
+import java.util.*
+import kotlin.test.assertEquals
+
+@Ignore
+class PRStateTest {
+    private val bob = PRParticipant(User("Bob", "bob@address.com",
+            1, "Bobby", Links(listOf(Links.Link("self_1")))), false, ParticipantStatus.UNAPPROVED)
+    private val aaron = PRParticipant(User("Aaron", "aaron@address.com",
+            1, "Aa", Links(listOf(Links.Link("self_2")))), false, ParticipantStatus.NEEDS_WORK)
+    private val repo = Repository("slug1", Project("key1"))
+    private val from = Branch("br1", repo)
+    private val to = Branch("br2", repo)
+
+    @Test
+    fun testCreateDiff() {
+//        val pr1 = PR(1, "PR#1", bob, false, from, to, setOf(bob, aaron),
+//                Date(1), Date(2), Links(listOf(Links.Link("href1"))), 0)
+//        val pr2 = PR(2, "PR#2", aaron, false, from, to, setOf(bob),
+//                Date(1), Date(2), Links(listOf(Links.Link("href2"))), 0)
+//
+//        val initialState = PRState().createNew(listOf(pr1, pr2))
+//
+//        //Bob understood that it is strange to be a reviewer of own pull request and removed himself :)
+//        val pr1NewState = PR(1, "PR#1", bob, false, from, to, setOf(aaron),
+//                Date(1), Date(2), Links(listOf(Links.Link("href1"))), 1)
+//        //PR#2 was merged so Aaron created a new one
+//        val pr3 = PR(3, "PR#3", aaron, false, from, to, setOf(bob),
+//                Date(1), Date(2), Links(listOf(Links.Link("href3"))), 0)
+//
+//        val diff = initialState.createDiff(listOf(pr1NewState, pr3))
+//        assertEquals(1, diff.added.size)
+//        assertEquals(1, diff.updated.size)
+//        assertEquals(1, diff.removed.size)
+//        assertEquals(pr3, diff.added[0])
+//        assertEquals(pr1NewState, diff.updated[0])
+//        assertEquals(pr2, diff.removed[0])
+
+    }
+
+}

--- a/src/test/kotlin/PRStateTest.kt
+++ b/src/test/kotlin/PRStateTest.kt
@@ -14,30 +14,31 @@ class PRStateTest {
     private val repo = Repository("slug1", Project("key1"))
     private val from = Branch("br1", repo)
     private val to = Branch("br2", repo)
+    private val props = PRProperties(1)
 
     @Test
     fun testCreateDiff() {
-//        val pr1 = PR(1, "PR#1", bob, false, from, to, setOf(bob, aaron),
-//                Date(1), Date(2), Links(listOf(Links.Link("href1"))), 0)
-//        val pr2 = PR(2, "PR#2", aaron, false, from, to, setOf(bob),
-//                Date(1), Date(2), Links(listOf(Links.Link("href2"))), 0)
-//
-//        val initialState = PRState().createNew(listOf(pr1, pr2))
-//
-//        //Bob understood that it is strange to be a reviewer of own pull request and removed himself :)
-//        val pr1NewState = PR(1, "PR#1", bob, false, from, to, setOf(aaron),
-//                Date(1), Date(2), Links(listOf(Links.Link("href1"))), 1)
-//        //PR#2 was merged so Aaron created a new one
-//        val pr3 = PR(3, "PR#3", aaron, false, from, to, setOf(bob),
-//                Date(1), Date(2), Links(listOf(Links.Link("href3"))), 0)
-//
-//        val diff = initialState.createDiff(listOf(pr1NewState, pr3))
-//        assertEquals(1, diff.added.size)
-//        assertEquals(1, diff.updated.size)
-//        assertEquals(1, diff.removed.size)
-//        assertEquals(pr3, diff.added[0])
-//        assertEquals(pr1NewState, diff.updated[0])
-//        assertEquals(pr2, diff.removed[0])
+        val pr1 = PR(1, "PR#1", bob, false, from, to, setOf(bob, aaron),
+                Date(1), Date(2), props, Links(listOf(Links.Link("href1"))), 0)
+        val pr2 = PR(2, "PR#2", aaron, false, from, to, setOf(bob),
+                Date(1), Date(2), props, Links(listOf(Links.Link("href2"))), 0)
+
+        val initialState = PRState().createNew(listOf(pr1, pr2))
+
+        //Bob understood that it is strange to be a reviewer of own pull request and removed himself
+        val pr1NewState = PR(1, "PR#1", bob, false, from, to, setOf(aaron),
+                Date(1), Date(2), props, Links(listOf(Links.Link("href1"))), 1)
+        //PR#2 was merged so Aaron created a new one
+        val pr3 = PR(3, "PR#3", aaron, false, from, to, setOf(bob),
+                Date(1), Date(2), props, Links(listOf(Links.Link("href3"))), 0)
+
+        val diff = initialState.createDiff(listOf(pr1NewState, pr3))
+        assertEquals(1, diff.added.size)
+        assertEquals(1, diff.updated.size)
+        assertEquals(1, diff.removed.size)
+        assertEquals(pr3, diff.added[0])
+        assertEquals(pr1NewState, diff.updated[0])
+        assertEquals(pr2, diff.removed[0])
 
     }
 

--- a/src/test/kotlin/PRTest.kt
+++ b/src/test/kotlin/PRTest.kt
@@ -12,14 +12,15 @@ class PRTest {
     private val repo = Repository("slug1", Project("key1"))
     private val from = Branch("br1", repo)
     private val to = Branch("br2", repo)
+    private val props = PRProperties(1)
     private val pr1 = PR(1, "PR#1", bob, false, from, to, setOf(bob, aaron),
-            Date(1), Date(2), Links(listOf(Links.Link("href0"))), 0)
+            Date(1), Date(2), props, Links(listOf(Links.Link("href0"))), 0)
 
     @Test
     fun testEquality() {
         //same as pr1, but Aaron and Bob are swapped
         val pr1Variation = PR(1, "PR#1", bob, false, from, to, setOf(aaron, bob),
-                Date(1), Date(2), Links(listOf(Links.Link("href0"))), 0)
+                Date(1), Date(2), props, Links(listOf(Links.Link("href0"))), 0)
         assertEquals(pr1, pr1Variation)
     }
 
@@ -28,7 +29,7 @@ class PRTest {
         val bobApproved = PRParticipant(User("Bob", "bob@address.com",
                 1, "Bobby", Links(listOf(Links.Link("self_1")))), true, ParticipantStatus.APPROVED)
         val pr1Variation = PR(1, "PR#1", bobApproved, false, from, to, setOf(bob, aaron),
-                Date(1), Date(2), Links(listOf(Links.Link("href0"))), 0)
+                Date(1), Date(2), props, Links(listOf(Links.Link("href0"))), 0)
         assertNotEquals(pr1, pr1Variation)
     }
 

--- a/src/test/kotlin/PanelRunner.kt
+++ b/src/test/kotlin/PanelRunner.kt
@@ -51,7 +51,7 @@ object PanelRunner {
         for (k in 0..id % 4)
             to += "8984"
         val repo = Repository("slug", Project("project_key"))
-
+        val props = PRProperties(1)
         val reviewers = HashSet<PRParticipant>()
         if (reviewersCount != 0) {
             for (userId in 0..reviewersCount) {
@@ -72,6 +72,7 @@ object PanelRunner {
                 Branch(to, repo),
                 reviewers,
                 Date(System.currentTimeMillis()), Date(System.currentTimeMillis()),
+                props,
                 Links(listOf(Links.Link("https://developer.atlassian.com/bitbucket/api/2/reference/"))),0
         )
     }


### PR DESCRIPTION
This is to deal with a possible issue which can be caused by the following sequence:
 - Update Task performs a regular request to sever for any PR updates 
 - User hits Merge button for own pull request
 - PR's "Merge" button becomes disabled, request to merge PR is sent to server
 - Update task receives the umerged state of the PR from the prev. step
 - Server responses that PR was merged successfully, the button remains disabled
 - UpdateTask calls Model with the stale PR state 
 - Merge button becomes enabled again

For user this looks like some error happened an PR wasn't merged, subsequent click on Merge button would cause new error.

This is a rare case, but I observed it once

