### PR TITLE
Authentication with personal access token

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,8 @@ The plugin supports two types of authentication: **Access Token auth** (requires
 ##### Access Token Auth
 If you are a happy user of Bitbucket Server version 5.5 or newer, you can use this convenient type of authentication.
 To generate a personal access token from within Bitbucket Server go to _Manage account > Account settings > Personal access tokens._
-Once a token is generated copy it to myBitbucket Settings. After you hit OK, plugin should show your pull requests.
+Create a token with a **Write** permission to be able to approve and merge pull requests from the plugin.
+Copy it to the myBitbucket Settings window. After you hit OK, plugin should show your pull requests.
 
 ##### Basic Auth with login and password
 For older versions you need to specify your Bibucket Server login in the Settings window and enter a password

--- a/README.md
+++ b/README.md
@@ -5,9 +5,18 @@ This plugin for Intellij IDEA allows you to see and approve pull-requests assign
 ![plugin example image](https://github.com/BigBurritoInc/BitbucketHelper4Idea/raw/master/src/main/resources/myBitbucket_example01.png)
 
 ## Configuring the plugin
-To configure the plugin open Idea's Settings window, navigate to **myBibucket** section, enter the base url with protocol, project and repository name (usually any pull-request’s url contains them in the following format: _<base_url>/projects/<project_name>/repos/<repo_name>/pull-requests/id_) and a username.
+To configure the plugin open Idea's Settings window, navigate to **myBibucket** section, enter the base url with protocol, project and repository name (usually any pull-request’s url contains them in the following format: _<base_url>/projects/<project_name>/repos/<repo_name>/pull-requests/id_).
 
-Then open myBibucket tab and enter your password. This plugin currently supports only basic authorization so it doesn’t store your password between sessions. If everything is fine, you will see a list of pull-requests assigned to you. If you don’t see any, check Idea’s event log for errors.
+The plugin supports two types of authentication: **Access Token auth** (requires Bitbucket Server 5.5 or higher) and **Basic auth** with login/password
+
+##### Access Token Auth
+If you are a happy user of Bitbucket Server version 5.5 or newer, you can use this convenient type of authentication.
+To generate a personal access token from within Bitbucket Server go to _Manage account > Account settings > Personal access tokens._
+Once a token is generated copy it to myBitbucket Settings. After you hit OK, plugin should show your pull requests.
+
+##### Basic Auth with login and password
+For older versions you need to specify your Bibucket Server login in the Settings window and enter a password
+in the "Login" tab of myBitbucket panel. Password is not persisted between sessions due to security reasons.
 
 ## Dependencies
 Requires “Git Integration” plugin to be enabled to use Git checkout.

--- a/src/main/kotlin/MainWindow.kt
+++ b/src/main/kotlin/MainWindow.kt
@@ -8,6 +8,7 @@ import com.intellij.ui.components.JBLabel
 import com.intellij.ui.components.panels.VerticalLayout
 import com.intellij.ui.content.Content
 import com.intellij.ui.content.ContentManager
+import com.intellij.ui.content.impl.TabbedContentImpl
 import ui.*
 import util.invokeLater
 import java.awt.*
@@ -19,6 +20,11 @@ import javax.swing.*
 class MainWindow : ToolWindowFactory, DumbAware {
 
     private var window: ToolWindow? = null
+    private var loginContent: Content = createDummyContent()
+    private var reviewingContent: Content = createDummyContent()
+    private var ownContent: Content = createDummyContent()
+
+    private fun createDummyContent() = TabbedContentImpl(JLabel(), "", false, "")
 
     override fun createToolWindowContent(prj: Project, window: ToolWindow) {
         this.window = window
@@ -26,9 +32,10 @@ class MainWindow : ToolWindowFactory, DumbAware {
         val reviewingPanel = createReviewPanel()
         val ownPanel = createOwnPanel()
 
-        val reviewingContent = addTab(cm, wrapIntoJBScroll(reviewingPanel), "Reviewing (0)")
-        val ownContent = addTab(cm, wrapIntoJBScroll(ownPanel), "Created (0)")
-        val loginContent = addTab(cm, createLoginPanel(cm, reviewingContent), "Login")
+        reviewingContent = addTab(cm, wrapIntoJBScroll(reviewingPanel), "Reviewing (0)")
+        ownContent = addTab(cm, wrapIntoJBScroll(ownPanel), "Created (0)")
+        val loginPanel = createLoginPanel(cm, reviewingContent)
+        loginContent = addTab(cm, loginPanel, "Login")
 
         Model.addListener(object: Listener {
             override fun ownCountChanged(count: Int) {
@@ -52,6 +59,7 @@ class MainWindow : ToolWindowFactory, DumbAware {
         invokeLater {
             if (getStorerService().settings.useAccessTokenAuth) {
                 getStorerService().settings.validate()
+                window!!.contentManager.setSelectedContent(reviewingContent)
                 UpdateTaskHolder.scheduleNew()
             }
         }

--- a/src/main/kotlin/MainWindow.kt
+++ b/src/main/kotlin/MainWindow.kt
@@ -47,8 +47,8 @@ class MainWindow : ToolWindowFactory, DumbAware {
     }
 
     private fun runUpdateTaskLater() {
-        //This has to be invoked after the MainWindow is constructed,
-        //otherwise StorerService is not available at the moment, so we use invokeLater
+        //This piece of code has to be invoked after the MainWindow is constructed, so we use invokeLater
+        //(StorerService is not available at the moment of window's construction)
         invokeLater {
             if (getStorerService().settings.useAccessTokenAuth) {
                 getStorerService().settings.validate()

--- a/src/main/kotlin/UpdateTaskHolder.kt
+++ b/src/main/kotlin/UpdateTaskHolder.kt
@@ -26,6 +26,13 @@ object UpdateTaskHolder {
         createAndRun { task.createNew(it) }
     }
 
+    fun stop() {
+        synchronized(lock) {
+            task.cancel()
+            task = DummyTask()
+        }
+    }
+
     private fun createAndRun(factory: (BitbucketClient) -> CancellableTask) {
         synchronized(lock) {
             //this lock is needed to make task initialization atomic

--- a/src/main/kotlin/bitbucket/BitbucketClient.kt
+++ b/src/main/kotlin/bitbucket/BitbucketClient.kt
@@ -12,8 +12,8 @@ import com.fasterxml.jackson.databind.ObjectReader
 import com.fasterxml.jackson.databind.ObjectWriter
 import com.intellij.openapi.diagnostic.Logger
 import com.palominolabs.http.url.UrlBuilder
-import http.HttpAuthRequestFactory
 import http.HttpResponseHandler
+import http.RequestFactory
 import org.apache.http.client.HttpClient
 import org.apache.http.client.methods.HttpUriRequest
 import org.apache.http.entity.ByteArrayEntity
@@ -22,7 +22,7 @@ import java.net.URL
 
 class BitbucketClient(
         private val httpClient: HttpClient,
-        private val httpRequestFactory: HttpAuthRequestFactory,
+        private val httpRequestFactory: RequestFactory,
         private val settings: Settings,
         objReader: ObjectReader,
         private val objWriter: ObjectWriter,

--- a/src/main/kotlin/bitbucket/BitbucketClientFactory.kt
+++ b/src/main/kotlin/bitbucket/BitbucketClientFactory.kt
@@ -2,7 +2,7 @@ package bitbucket
 
 import com.fasterxml.jackson.databind.DeserializationFeature
 import com.fasterxml.jackson.databind.ObjectMapper
-import http.HttpAuthRequestFactory
+import http.BasicAuthRequestFactory
 import org.apache.http.client.HttpClient
 import org.apache.http.impl.client.HttpClients
 import ui.getStorerService
@@ -19,7 +19,7 @@ object BitbucketClientFactory {
 
         return BitbucketClient(
                 createHttpClient(),
-                HttpAuthRequestFactory(settings.login, String(password)),
+                BasicAuthRequestFactory(settings.login, String(password)),
                 settings, objectMapper.reader(), objectMapper.writer(), listener)
     }
 

--- a/src/main/kotlin/bitbucket/BitbucketClientFactory.kt
+++ b/src/main/kotlin/bitbucket/BitbucketClientFactory.kt
@@ -2,6 +2,7 @@ package bitbucket
 
 import com.fasterxml.jackson.databind.DeserializationFeature
 import com.fasterxml.jackson.databind.ObjectMapper
+import http.AccessTokenRequestFactory
 import http.BasicAuthRequestFactory
 import org.apache.http.client.HttpClient
 import org.apache.http.impl.client.HttpClients
@@ -16,10 +17,14 @@ object BitbucketClientFactory {
         val objectMapper = ObjectMapper()
         objectMapper.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false)
         val settings = storer.settings
-
+        val requestFactory = if (settings.useAccessTokenAuth) {
+            AccessTokenRequestFactory(settings.accessToken)
+        } else {
+            BasicAuthRequestFactory(settings.login, String(password))
+        }
         return BitbucketClient(
                 createHttpClient(),
-                BasicAuthRequestFactory(settings.login, String(password)),
+                requestFactory,
                 settings, objectMapper.reader(), objectMapper.writer(), listener)
     }
 

--- a/src/main/kotlin/http/AccessTokenRequestFactory.kt
+++ b/src/main/kotlin/http/AccessTokenRequestFactory.kt
@@ -1,0 +1,13 @@
+package http
+
+import org.apache.http.HttpHeaders
+import org.apache.http.HttpMessage
+
+/**
+ * This implementation of RequestFactory creates requests that use Access Token to authenticate in Bitbucket.
+ */
+class AccessTokenRequestFactory(private val token: String): RequestFactory() {
+    override fun addAuthHeader(request: HttpMessage) {
+        request.setHeader(HttpHeaders.AUTHORIZATION, "Bearer $token")
+    }
+}

--- a/src/main/kotlin/http/BasicAuthRequestFactory.kt
+++ b/src/main/kotlin/http/BasicAuthRequestFactory.kt
@@ -1,0 +1,23 @@
+package http
+
+import org.apache.http.HttpHeaders
+import org.apache.http.HttpMessage
+import java.nio.charset.StandardCharsets
+import java.util.*
+
+/**
+ * This implementation of RequestFactory creates HTTP-requests
+ * that use Basic Auth with username and password.
+ */
+class BasicAuthRequestFactory(private val user: String, private val password: String): RequestFactory() {
+
+    override fun addAuthHeader(request: HttpMessage) {
+        val authHeader = "Basic " + authString()
+        request.setHeader(HttpHeaders.AUTHORIZATION, authHeader)
+    }
+
+    private fun authString(): String {
+        val authArray = ("$user:$password").toByteArray(StandardCharsets.UTF_8)
+        return Base64.getEncoder().encodeToString(authArray)
+    }
+}

--- a/src/main/kotlin/http/RequestFactory.kt
+++ b/src/main/kotlin/http/RequestFactory.kt
@@ -1,14 +1,11 @@
 package http
 
-import org.apache.http.HttpHeaders
 import org.apache.http.HttpMessage
 import org.apache.http.client.methods.HttpGet
 import org.apache.http.client.methods.HttpPost
 import org.apache.http.client.methods.HttpPut
-import java.nio.charset.StandardCharsets
-import java.util.*
 
-class HttpAuthRequestFactory(private val user: String, private val password: String) {
+abstract class RequestFactory {
 
     fun createPost(url: String): HttpPost {
         val request = HttpPost(url)
@@ -29,15 +26,7 @@ class HttpAuthRequestFactory(private val user: String, private val password: Str
         return request
     }
 
-    private fun addAuthHeader(request: HttpMessage) {
-        val authHeader = "Basic " + authString()
-        request.setHeader(HttpHeaders.AUTHORIZATION, authHeader)
-    }
-
-    private fun authString(): String {
-        val authArray = ("$user:$password").toByteArray(StandardCharsets.UTF_8)
-        return Base64.getEncoder().encodeToString(authArray)
-    }
+    abstract fun addAuthHeader(request: HttpMessage);
 
     private fun addContentTypeHeader(request: HttpMessage) {
         request.setHeader("Content-Type", "application/json")

--- a/src/main/kotlin/ui/Configurable.kt
+++ b/src/main/kotlin/ui/Configurable.kt
@@ -6,6 +6,7 @@ import com.intellij.openapi.components.*
 import com.intellij.openapi.options.Configurable
 import com.intellij.openapi.options.ConfigurationException
 import com.intellij.openapi.options.SearchableConfigurable
+import com.intellij.ui.components.JBCheckBox
 import java.awt.BorderLayout
 import javax.swing.*
 
@@ -58,7 +59,7 @@ class BitbucketHelperConfigurable : SearchableConfigurable, Configurable.NoScrol
     private val slugField = JTextField()
     private val urlField = JTextField()
     private val loginField = JTextField()
-    private val useAccessTokenCheckbox = JCheckBox()
+    private val useAccessTokenCheckbox = JBCheckBox("Use Access Token")
     private val accessTokenField = JTextField()
 
     override fun createComponent(): JComponent? {
@@ -97,9 +98,9 @@ class BitbucketHelperConfigurable : SearchableConfigurable, Configurable.NoScrol
         gbc.gridy++
         mainPanel.add(useAccessTokenCheckbox, gbc)
         gbc.gridy++
+        useAccessTokenCheckbox.addChangeListener { accessTokenField.isVisible = useAccessTokenCheckbox.isSelected }
+        accessTokenField.isVisible = false
         mainPanel.add(accessTokenField, gbc)
-        accessTokenField.isVisible = useAccessTokenCheckbox.isEnabled
-        useAccessTokenCheckbox.addActionListener { accessTokenField.isVisible = useAccessTokenCheckbox.isEnabled }
         val wrapper = JPanel(BorderLayout())
         wrapper.add(mainPanel, BorderLayout.NORTH)
         return wrapper
@@ -111,7 +112,7 @@ class BitbucketHelperConfigurable : SearchableConfigurable, Configurable.NoScrol
         urlField.text = settings.url
         loginField.text = settings.login
         accessTokenField.text = settings.accessToken
-        useAccessTokenCheckbox.isEnabled = settings.useAccessTokenAuth
+        useAccessTokenCheckbox.isSelected = settings.useAccessTokenAuth
     }
 }
 
@@ -132,7 +133,7 @@ data class Settings(var project: String = "", var slug: String = "", var login: 
             throw ConfigurationException("Fill all the BitBucket settings", "Some settings are blank")
         if (useAccessTokenAuth && accessToken.isBlank()) {
             throw ConfigurationException(
-                    "You have chosen Access token auth, a token needs to be specified", "Access Token is blank")
+                    "You have chosen Access Token auth, a token needs to be specified", "Access Token is blank")
         }
         try {
             URL(url)

--- a/src/test/kotlin/Runner.kt
+++ b/src/test/kotlin/Runner.kt
@@ -2,7 +2,7 @@ import bitbucket.BitbucketClient
 import bitbucket.ClientListener
 import com.fasterxml.jackson.databind.DeserializationFeature
 import com.fasterxml.jackson.databind.ObjectMapper
-import http.HttpAuthRequestFactory
+import http.BasicAuthRequestFactory
 import org.apache.http.impl.client.HttpClients
 import ui.Settings
 
@@ -17,7 +17,7 @@ object Runner {
         settings.slug = args[4]
         val client = BitbucketClient(
                 HttpClients.createDefault(),
-                HttpAuthRequestFactory(args[0], args[1]),
+                BasicAuthRequestFactory(args[0], args[1]),
                 settings,
                 objectMapper.reader(), objectMapper.writer(),
                 object: ClientListener {


### PR DESCRIPTION
A support of personal access token is added. Unlike password, token is persisted between sessions so used doesn't have to enter anything after IDE starts. Now there are two request factories: for basic auth and access token auth.
Readme.md is also updated to reflect the changes.

Issue #66 